### PR TITLE
feat: allow to skip the initial token check

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -101,3 +101,18 @@ func TestNewHumanitecClientMissingToken(t *testing.T) {
 	})
 	assert.ErrorIs(err, ErrMissingToken)
 }
+
+func TestNewHumanitecClientMissingTokenSkipCheck(t *testing.T) {
+	assert := assert.New(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Fail("Shouldn't be called")
+	}))
+	defer srv.Close()
+
+	_, err := NewClient(&Config{
+		URL:                   srv.URL,
+		SkipInitialTokenCheck: true,
+	})
+	assert.NoError(err)
+}


### PR DESCRIPTION
Allow to skip the initial token check, which can be useful if we you want to initiate in a shared context, but not necessarily have a token available in all cases.